### PR TITLE
メッセージを編集できるようにする #55

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -4,7 +4,7 @@ class MessagesController < ApplicationController
   before_action :check_owner, only: [:edit, :update]
 
   def create
-    @message = current_user.messages.create(message_params_merge_room)
+    @message = current_user.messages.create(message_params_on_create)
     redirect_to request.referer
   end
 
@@ -12,7 +12,7 @@ class MessagesController < ApplicationController
   end
 
   def update
-    if @message.update(message_params)
+    if @message.update(message_params_on_update)
       redirect_to room_path(@message.room_id) , notice: 'メッセージが更新されました。'
     else
       render :edit
@@ -25,11 +25,11 @@ class MessagesController < ApplicationController
     @message = Message.find(params[:id])
   end
 
-  def message_params
+  def message_params_on_update
     params.require(:message).permit(:body)
   end
 
-  def message_params_merge_room
+  def message_params_on_create
     params.require(:message).permit(:body).merge(room_id: params[:room_id])
   end
 

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,15 +1,35 @@
 class MessagesController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_message, only: [:edit, :update]
 
 
   def create
-    @message = current_user.messages.create(message_params)
+    @message = current_user.messages.create(message_params_merge_room)
     redirect_to request.referer
+  end
+
+  def edit
+  end
+
+  def update
+    if @message.update(message_params)
+      redirect_to room_path(@message.room_id) , notice: 'メッセージが更新されました。'
+    else
+      render :edit
+    end
   end
 
   private
 
+  def set_message
+    @message = Message.find(params[:id])
+  end
+
   def message_params
+    params.require(:message).permit(:body)
+  end
+
+  def message_params_merge_room
     params.require(:message).permit(:body).merge(room_id: params[:room_id])
   end
 

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,7 +1,7 @@
 class MessagesController < ApplicationController
   before_action :authenticate_user!
   before_action :set_message, only: [:edit, :update]
-
+  before_action :check_owner, only: [:edit, :update]
 
   def create
     @message = current_user.messages.create(message_params_merge_room)
@@ -31,6 +31,11 @@ class MessagesController < ApplicationController
 
   def message_params_merge_room
     params.require(:message).permit(:body).merge(room_id: params[:room_id])
+  end
+
+  def check_owner
+    return if @message.user == current_user
+    redirect_to room_path(@message.room_id), alert: '他のユーザーのメッセージを編集することはできません。'
   end
 
 end

--- a/app/views/messages/edit.html.erb
+++ b/app/views/messages/edit.html.erb
@@ -1,0 +1,10 @@
+<div class="container">  
+  <%= form_with model: @message, url: message_path, data: { turbo_method: :put }, local: true do |f| %>
+    <div class="form-label mt-4">
+      <%= f.text_area :body, placeholder: 'メッセージを入力', class: 'form-control' %>
+    </div>
+    <div class="actions text-center">
+      <%= f.submit '送信', class: 'btn btn-lg msg-send-btn btn-block' %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -28,14 +28,23 @@
 
 
 <!--メッセージのやりとり履歴-->
-<div class=" mt-5 ">
+<div class="mt-5">
   <% if @all_message_exchanges.present? %>
     <% @all_message_exchanges.each do |message| %>
       <div class="message-form mt-2 border border-2">
-        <div class="card-body object-fit-fill ">
+        <div class="card-body object-fit-fill">
           <div class="card mb-4 p-3">
             <div class="d-flex justify-content-between">
+        <div class="d-flex align-items-center"> 
               <p><%= message.user.profile.name %></p>
+              <p>
+              <!-- 自分のメッセージであるかのチェック -->
+              <% if current_user == message.user %>
+                <!-- 編集リンクを表示 -->
+                <%= link_to '編集', edit_message_path(message) %>
+              <% end %>
+              </p>
+              </div>
               <p><%= time_ago_in_words(message.updated_at) %>前</p>
             </div>
             <p><%= message.body %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,4 +29,5 @@ Rails.application.routes.draw do
   resources :rooms do
     resources :messages, only: [:index,:new, :create]
   end
+  resources :messages, only: [:edit, :update, :destroy]
 end


### PR DESCRIPTION
# メッセージを編集できるようにする #55

## 概要
メッセージの編集機能を作成する。
編集できるのは自分の作成したメッセージのみ。

## 完了条件
メッセージ詳細画面にて、自分のメッセージが編集できること
メッセージ詳細画面にて、他人のメッセージは編集できないこと
関連するテストが追加され、全てパスしていること