### PR TITLE
ペット登録後1週間はトップページにてNewマークを表示する #62

### DIFF
--- a/app/assets/stylesheets/shared/main.scss
+++ b/app/assets/stylesheets/shared/main.scss
@@ -238,3 +238,14 @@ body {
   margin: auto;
   background-color: white;
 }
+
+.new-mark {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    background-color: rgba(255, 0, 0, 0.7);  // 赤色の背景を半透明に
+    color: white;  // 文字色を白に
+    padding: 5px 10px;  // パディングを調整
+    font-weight: bold;  // ボールドに
+    z-index: 10;  // 他の要素より前面に表示
+}

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -35,7 +35,6 @@ class Pet < ApplicationRecord
 
   def new?
     end_of_new_period = (self.created_at + 6.days).end_of_day
-
     Time.now <= end_of_new_period
   end
 end

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -32,4 +32,10 @@ class Pet < ApplicationRecord
   def favorite?(viewer)
     favorites.detect{ |user| user.user_id == viewer.id }.present?
   end
+
+  def new?
+    end_of_new_period = (self.created_at + 6.days).end_of_day
+
+    Time.now <= end_of_new_period
+  end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -67,7 +67,11 @@
             <div class="card my-2">
               <% if pet.pet_images.present? %>
                 <%= image_tag pet.pet_images.first.photo.to_s, class: 'card-img-top' %>
+                <% if pet.new? %>
+                    <span class="new-mark">New</span>
+                <% end %>
               <% end %>
+
               <div class="card-body">
                 <h5 class="card-title petname"><%= pet.petname %></h5>
                 <p><%= pet.classification_i18n %>/<%= pet.age %>才/<%= pet.gender_i18n %></p>

--- a/spec/features/home_index_spec.rb
+++ b/spec/features/home_index_spec.rb
@@ -173,4 +173,30 @@ RSpec.feature 'ホーム画面', type: :feature do
       expect(page).to have_content '★ 気になるリストに追加'
     end
   end
+
+  describe '新着表示' do
+    before do
+      visit root_path
+    end
+
+    scenario "7日を超えるペットが追加されても、新着表示が増えないこと" do
+      initial_count = page.all("span.new-mark").count
+
+      create(:pet, created_at: 7.days.ago)
+      visit root_path
+      final_count = page.all("span.new-mark").count
+
+      expect(final_count).to eq(initial_count)
+    end
+
+    scenario "6日以内のペットが追加された場合、新着表示が増えること" do
+      initial_count = page.all("span.new-mark").count
+
+      create(:pet, created_at: 5.days.ago)
+      visit root_path
+      final_count = page.all("span.new-mark").count
+
+      expect(final_count).to eq(initial_count + 1)
+    end
+  end
 end

--- a/spec/features/home_index_spec.rb
+++ b/spec/features/home_index_spec.rb
@@ -176,20 +176,21 @@ RSpec.feature 'ホーム画面', type: :feature do
 
   describe '新着表示' do
     before do
+      Pet.destroy_all
       visit root_path
     end
 
-    scenario "7日を超えるペットが追加されても、新着表示が増えないこと" do
+    scenario "7日を超えるペットが追加されても、新着表示が増えないこと（表示されていないこと）" do
       initial_count = page.all("span.new-mark").count
 
       create(:pet, created_at: 7.days.ago)
       visit root_path
       final_count = page.all("span.new-mark").count
-
       expect(final_count).to eq(initial_count)
+      expect(page).not_to have_css("span.new-mark")
     end
 
-    scenario "6日以内のペットが追加された場合、新着表示が増えること" do
+    scenario "6日以内のペットが追加された場合、新着表示が増えること（表示されてること）" do
       initial_count = page.all("span.new-mark").count
 
       create(:pet, created_at: 5.days.ago)
@@ -197,6 +198,7 @@ RSpec.feature 'ホーム画面', type: :feature do
       final_count = page.all("span.new-mark").count
 
       expect(final_count).to eq(initial_count + 1)
+      expect(page).to have_css("span.new-mark")
     end
   end
 end

--- a/spec/features/home_index_spec.rb
+++ b/spec/features/home_index_spec.rb
@@ -10,24 +10,27 @@ RSpec.feature 'ホーム画面', type: :feature do
   end
 
   let(:pet) do
-    create(:pet,
-           category: :dog,
-           petname: 'taro20221101',
-           age: 12,
-           gender: :male,
-           classification: :Chihuahua,
-           introduction: 'おとなしく、賢い',
-           castration: :neutered,
-           vaccination: :vaccinated,
-           recruitment_status: 0,
-           user_id: user.id)
+    created_pet = create(:pet,
+          category: :dog,
+          petname: 'taro20221101',
+          age: 12,
+          gender: :male,
+          classification: :Chihuahua,
+          introduction: 'おとなしく、賢い',
+          castration: :neutered,
+          vaccination: :vaccinated,
+          recruitment_status: 0,
+          user_id: user.id)
+    create(:pet_area, pet_id: created_pet.id, area_id: area.id)
+    created_pet
   end
 
-  before do
-    create(:pet_area, pet_id: pet.id, area_id: area.id)
-  end
 
   describe 'ペット一覧表示' do
+    before do
+      pet
+    end
+
     scenario '未ログイン状態で表示されていること' do
       visit root_path
       expect(page).to have_content 'taro20221101'
@@ -41,6 +44,7 @@ RSpec.feature 'ホーム画面', type: :feature do
   end
   describe '検索機能' do
     before do
+      pet
       create(:area, place_name: '東京')
     end
     context '組合せ検索' do
@@ -157,6 +161,7 @@ RSpec.feature 'ホーム画面', type: :feature do
 
   describe 'お気に入り機能' do
     before do
+      pet
       user_favorite = create(:user, email: 'test121212@test.com', password: 'password', password_confirmation: 'password', &:confirm)
       sign_in  user_favorite
       visit root_path
@@ -176,7 +181,6 @@ RSpec.feature 'ホーム画面', type: :feature do
 
   describe '新着表示' do
     before do
-      Pet.destroy_all
       visit root_path
     end
 

--- a/spec/models/pet_spec.rb
+++ b/spec/models/pet_spec.rb
@@ -43,4 +43,40 @@ RSpec.describe Pet, type: :model do
       expect(pet.errors[:vaccination]).to include('を入力してください')
     end
   end
+
+  describe '#new?' do
+    let(:pet) { build(:pet, created_at: created_at) }
+
+    context 'ペットが6日以内に作成された場合' do
+      let(:created_at) { 5.days.ago }
+
+      it 'trueを返すこと' do
+        expect(pet.new?).to be_truthy
+      end
+    end
+
+    context 'ペットがちょうど6日後の23:59に作成された場合' do
+      let(:created_at) { 6.days.ago.change(hour: 23, min: 59) }
+
+      it 'trueを返すこと' do
+        expect(pet.new?).to be_truthy
+      end
+    end
+
+    context 'ペットがちょうど7日00:00に作成された場合' do
+      let(:created_at) { 7.days.ago.change(hour: 0, min: 0) }
+
+      it 'falseを返すこと' do
+        expect(pet.new?).to be_falsey
+      end
+    end
+
+    context 'ペットが6日より前に作成された場合' do
+      let(:created_at) { 7.days.ago }
+
+      it 'falseを返すこと' do
+        expect(pet.new?).to be_falsey
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要
ペット登録後1週間はトップページにて New マークを表示する
例えば、7/1 10:00 に登録された場合、7/7 23:59まで新着扱いとする

## 完了条件
ペットを登録後一週間の間は New マークが表示されていること
ペットを登録後一週間を過ぎたペットには New マークが表示されていないこと