### PR TITLE
ユーザーページ追加ユーザーページの作成 #59

### DIFF
--- a/app/controllers/members/pets_controller.rb
+++ b/app/controllers/members/pets_controller.rb
@@ -2,8 +2,7 @@ module Members
   class PetsController < ApplicationController
     def index
       member = User.find(params[:member_id])
-      @pets = Pet.preload(:pet_images, :pet_areas, :areas, :user, :favorites, :rooms)
-               .where(user_id:  member.id)
+      @pets = member.pets.preload(:pet_images, :pet_areas, :areas, :user, :favorites, :rooms)
                .page(params[:page]).per(20)
     end
   end

--- a/app/controllers/members/pets_controller.rb
+++ b/app/controllers/members/pets_controller.rb
@@ -1,0 +1,10 @@
+module Members
+  class PetsController < ApplicationController
+    def index
+      member = User.find(params[:member_id])
+      @pets = Pet.preload(:pet_images, :pet_areas, :areas, :user, :favorites, :rooms)
+               .where(user_id:  member.id)
+               .page(params[:page]).per(20)
+    end
+  end
+end

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -1,16 +1,10 @@
 class MembersController < ApplicationController
 
-  def index
-    @user = User.find(params[:user_id])
+  def show
+    @member = User.find(params[:id])
+    @pets = @member.pets.limit(4)
 
-    total_pets_count = @user.pets.count
-
-    if params[:all]
-      @pets = @user.pets.all
-    else
-      @pets = @user.pets.limit(4)
-    end
-
+    total_pets_count = @member.pets.count
     @show_more_link = total_pets_count > 4 && @pets.count < total_pets_count
   end
 end

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -1,10 +1,10 @@
 class MembersController < ApplicationController
 
   def show
-    @member = User.find(params[:id])
-    @pets = @member.pets.limit(4)
+    member = User.find(params[:id])
+    @pets = Pet.preload(:pet_images, :pet_areas, :areas, :user, :favorites, :rooms).where(user_id:  member.id).limit(4)
 
-    total_pets_count = @member.pets.count
+    total_pets_count = member.pets.count
     @show_more_link = total_pets_count > 4 && @pets.count < total_pets_count
   end
 end

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -4,7 +4,6 @@ class MembersController < ApplicationController
     member = User.find(params[:id])
     @pets = Pet.preload(:pet_images, :pet_areas, :areas, :user, :favorites, :rooms).where(user_id:  member.id).limit(4)
 
-    total_pets_count = member.pets.count
-    @show_more_link = total_pets_count > 4 && @pets.count < total_pets_count
+    @show_more_link = member.pets.offset(4).exists?
   end
 end

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -1,0 +1,16 @@
+class MembersController < ApplicationController
+
+  def index
+    @user = User.find(params[:user_id])
+
+    total_pets_count = @user.pets.count
+
+    if params[:all]
+      @pets = @user.pets.all
+    else
+      @pets = @user.pets.limit(4)
+    end
+
+    @show_more_link = total_pets_count > 4 && @pets.count < total_pets_count
+  end
+end

--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -3,7 +3,9 @@ class PetsController < ApplicationController
 
 def index
     member = User.find(params[:id])
-    @pets = Pet.preload(:pet_images, :pet_areas, :areas, :user, :favorites, :rooms).where(user_id:  member.id)
+    @pets = Pet.preload(:pet_images, :pet_areas, :areas, :user, :favorites, :rooms)
+               .where(user_id:  member.id)
+               .page(params[:page]).per(20)
 end
 
   def new

--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -2,8 +2,8 @@ class PetsController < ApplicationController
   before_action :authenticate_user!, except: [:show, :index]
 
 def index
-    @user = User.find(params[:id])
-    @pets = @user.pets.all
+    member = User.find(params[:id])
+    @pets = Pet.preload(:pet_images, :pet_areas, :areas, :user, :favorites, :rooms).where(user_id:  member.id)
 end
 
   def new

--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -1,9 +1,19 @@
 class PetsController < ApplicationController
   before_action :authenticate_user!, except: [:show, :index]
 
-  def index
-    @pets = Pet.all
+def index
+  @user = User.find(params[:user_id])
+
+  total_pets_count = @user.pets.count
+
+  if params[:all]
+     @pets = @user.pets.all
+  else
+     @pets = @user.pets.limit(4)
   end
+
+  @show_more_link = total_pets_count > 4 && @pets.count < total_pets_count
+end
 
   def new
     # pet ペット情報を保存　petForm 画像を保存で分ける

--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -2,6 +2,8 @@ class PetsController < ApplicationController
   before_action :authenticate_user!, except: [:show, :index]
 
 def index
+    @user = User.find(params[:id])
+    @pets = @user.pets.all
 end
 
   def new

--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -2,10 +2,6 @@ class PetsController < ApplicationController
   before_action :authenticate_user!, except: [:show, :index]
 
 def index
-    member = User.find(params[:id])
-    @pets = Pet.preload(:pet_images, :pet_areas, :areas, :user, :favorites, :rooms)
-               .where(user_id:  member.id)
-               .page(params[:page]).per(20)
 end
 
   def new

--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -2,17 +2,6 @@ class PetsController < ApplicationController
   before_action :authenticate_user!, except: [:show, :index]
 
 def index
-  @user = User.find(params[:user_id])
-
-  total_pets_count = @user.pets.count
-
-  if params[:all]
-     @pets = @user.pets.all
-  else
-     @pets = @user.pets.limit(4)
-  end
-
-  @show_more_link = total_pets_count > 4 && @pets.count < total_pets_count
 end
 
   def new

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -61,43 +61,9 @@
     <hr>
     <div class='mt-5'>
       <div class="row">
-        <% @pets.each do |pet| %>
-          <div class="col-3">
-
-            <div class="card my-2">
-              <% if pet.pet_images.present? %>
-                <%= image_tag pet.pet_images.first.photo.to_s, class: 'card-img-top' %>
-              <% end %>
-              <div class="card-body">
-                <h5 class="card-title petname"><%= pet.petname %></h5>
-                <p><%= pet.classification_i18n %>/<%= pet.age %>才/<%= pet.gender_i18n %></p>
-                <h5 class="card-title">譲渡可能地域</h5>
-                <% pet.pet_areas.each do |a| %>
-                  <%= a.area.place_name %>
-                <% end %>
-                <p class="card-text"><%= pet.introduction %></p>
-                <div class="button_to">
-                  <%= link_to 'ペット詳細情報を確認', pet_path(pet.id), class: "btn btn-primary " %>
-                </div>
-                <% if user_signed_in? && pet.own?(current_user).blank? %>
-                  <% if pet.favorite?(current_user) %>
-                    <%= button_to pet_favorites_path(pet.id), method: :delete, class: 'btn favorite-btn-off' do %>
-                      <div class='favorite-registration-part-off'>
-                        <span class='star-non'>☆</span> <span class='favorite-text'>気になるリストから削除</span>
-                      </div>
-                    <% end %>
-                  <% else %>
-                    <%= button_to pet_favorites_path(pet.id), data: { turbo_method: :post }, class: 'btn favorite-btn-on' do %>
-                      <div class='favorite-registration-part-on'>
-                        <span class='star'>★</span> <span class='favorite-text'>気になるリストに追加</span>
-                      </div>
-                    <% end %>
-                  <% end %>
-                <% end %>
-              </div>
-            </div>
-          </div>
-        <% end %>
+      <% @pets.each do |pet| %>
+        <%= render 'pets/pet_card', pet: pet %>
+      <% end %>
       </div>
     </div>
   </div>

--- a/app/views/members/index.html.erb
+++ b/app/views/members/index.html.erb
@@ -1,11 +1,7 @@
 <h1>掲載中の里親募集</h1>
 
 <div class="container">
-  <% if @pets.empty? %>
-    <h2>現在掲載中の募集はありません。</h2>
-  <% else %>
-    <%= render 'pets/pet_list', locals: { pets: @pets }%>
-  <% end %>
+  <%= render 'pets/pet_list', locals: { pets: @pets }%>
   <% if @show_more_link %>
     <div class="mt-3">
       <p><%= link_to 'もっと見る', members_pets_path(all: true, user_id: params[:user_id]), class: 'btn btn-secondary' %></p>

--- a/app/views/members/index.html.erb
+++ b/app/views/members/index.html.erb
@@ -6,27 +6,13 @@
   <% else %>
     <div class="row">
       <% @pets.each do |pet| %>
-        <div class="col-3">
-
-          <div class="card my-2">
-            <% if pet.pet_images.present? %>
-              <%= image_tag pet.pet_images.first.photo.to_s, class: 'card-img-top' %>
-            <% end %>
-            <div class="card-body">
-              <h5 class="card-title"><%= pet.petname %></h5>
-              <p><%= pet.classification_i18n %>/<%= pet.age %>才/<%= pet.gender_i18n %></p>
-              <h5 class="card-title">譲渡可能地域</h5>
-              <p class="card-text"><%= pet.introduction %></p>
-              <%= link_to 'ペット詳細情報を確認', pet_path(pet.id), class: "btn btn-primary" %>
-            </div>
-          </div>
-        </div>
+        <%= render 'pets/pet_card', pet: pet %>
       <% end %>
     </div>
   <% end %>
   <% if @show_more_link %>
     <div class="mt-3">
-      <p><%= link_to 'もっと見る', pets_path(all: true,user_id: params[:user_id]), class: 'btn btn-secondary' %></p>
+      <p><%= link_to 'もっと見る', members_pets_path(all: true, user_id: params[:user_id]), class: 'btn btn-secondary' %></p>
     </div>
   <% end %>
 </div>

--- a/app/views/members/index.html.erb
+++ b/app/views/members/index.html.erb
@@ -1,0 +1,32 @@
+<h1>掲載中の里親募集</h1>
+
+<div class="container">
+  <% if @pets.empty? %>
+    <h2>現在掲載中の募集はありません。</h2>
+  <% else %>
+    <div class="row">
+      <% @pets.each do |pet| %>
+        <div class="col-3">
+
+          <div class="card my-2">
+            <% if pet.pet_images.present? %>
+              <%= image_tag pet.pet_images.first.photo.to_s, class: 'card-img-top' %>
+            <% end %>
+            <div class="card-body">
+              <h5 class="card-title"><%= pet.petname %></h5>
+              <p><%= pet.classification_i18n %>/<%= pet.age %>才/<%= pet.gender_i18n %></p>
+              <h5 class="card-title">譲渡可能地域</h5>
+              <p class="card-text"><%= pet.introduction %></p>
+              <%= link_to 'ペット詳細情報を確認', pet_path(pet.id), class: "btn btn-primary" %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+  <% if @show_more_link %>
+    <div class="mt-3">
+      <p><%= link_to 'もっと見る', pets_path(all: true,user_id: params[:user_id]), class: 'btn btn-secondary' %></p>
+    </div>
+  <% end %>
+</div>

--- a/app/views/members/index.html.erb
+++ b/app/views/members/index.html.erb
@@ -4,11 +4,7 @@
   <% if @pets.empty? %>
     <h2>現在掲載中の募集はありません。</h2>
   <% else %>
-    <div class="row">
-      <% @pets.each do |pet| %>
-        <%= render 'pets/pet_card', pet: pet %>
-      <% end %>
-    </div>
+    <%= render 'pets/pet_list', locals: { pets: @pets }%>
   <% end %>
   <% if @show_more_link %>
     <div class="mt-3">

--- a/app/views/members/pets/index.html.erb
+++ b/app/views/members/pets/index.html.erb
@@ -1,0 +1,6 @@
+<h1>掲載中の里親募集</h1>
+
+<div class="container">
+  <%= render 'pets/pet_list', locals: { pets: @pets }%>
+  <%= paginate @pets, theme: 'bootstrap-5' %>
+</div>

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -4,7 +4,7 @@
   <%= render 'pets/pet_list', locals: { pets: @pets }%>
   <% if @show_more_link %>
     <div class="mt-3">
-      <p><%= link_to 'もっと見る', pets_member_path(params[:id]), class: 'btn btn-secondary' %></p>
+      <p><%= link_to 'もっと見る', member_pets_path(member_id: params[:id]), class: 'btn btn-secondary' %></p>
     </div>
   <% end %>
 </div>

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -1,0 +1,10 @@
+<h1>掲載中の里親募集</h1>
+
+<div class="container">
+  <%= render 'pets/pet_list', locals: { pets: @pets }%>
+  <% if @show_more_link %>
+    <div class="mt-3">
+      <p><%= link_to 'もっと見る', pets_member_path(params[:id]), class: 'btn btn-secondary' %></p>
+    </div>
+  <% end %>
+</div>

--- a/app/views/pets/_pet_card.html.erb
+++ b/app/views/pets/_pet_card.html.erb
@@ -1,5 +1,4 @@
         <div class="col-3">
-
           <div class="card my-2">
             <% if pet.pet_images.present? %>
               <%= image_tag pet.pet_images.first.photo.to_s, class: 'card-img-top' %>

--- a/app/views/pets/_pet_card.html.erb
+++ b/app/views/pets/_pet_card.html.erb
@@ -14,7 +14,7 @@
               <div class="button_to">
                 <%= link_to 'ペット詳細情報を確認', pet_path(pet.id), class: "btn btn-primary " %>
               </div>
-              <% if user_signed_in? && pet.own?(current_user).blank? %>
+              <% if user_signed_in? && !pet.own?(current_user) %>
                 <% if pet.favorite?(current_user) %>
                   <%= button_to pet_favorites_path(pet.id), method: :delete, class: 'btn favorite-btn-off' do %>
                     <div class='favorite-registration-part-off'>

--- a/app/views/pets/_pet_card.html.erb
+++ b/app/views/pets/_pet_card.html.erb
@@ -1,0 +1,35 @@
+        <div class="col-3">
+
+          <div class="card my-2">
+            <% if pet.pet_images.present? %>
+              <%= image_tag pet.pet_images.first.photo.to_s, class: 'card-img-top' %>
+            <% end %>
+            <div class="card-body">
+              <h5 class="card-title petname"><%= pet.petname %></h5>
+              <p><%= pet.classification_i18n %>/<%= pet.age %>才/<%= pet.gender_i18n %></p>
+              <h5 class="card-title">譲渡可能地域</h5>
+              <% pet.pet_areas.each do |a| %>
+                <%= a.area.place_name %>
+              <% end %>
+              <p class="card-text"><%= pet.introduction %></p>
+              <div class="button_to">
+                <%= link_to 'ペット詳細情報を確認', pet_path(pet.id), class: "btn btn-primary " %>
+              </div>
+              <% if user_signed_in? && pet.own?(current_user).blank? %>
+                <% if pet.favorite?(current_user) %>
+                  <%= button_to pet_favorites_path(pet.id), method: :delete, class: 'btn favorite-btn-off' do %>
+                    <div class='favorite-registration-part-off'>
+                      <span class='star-non'>☆</span> <span class='favorite-text'>気になるリストから削除</span>
+                    </div>
+                  <% end %>
+                <% else %>
+                  <%= button_to pet_favorites_path(pet.id), data: { turbo_method: :post }, class: 'btn favorite-btn-on' do %>
+                    <div class='favorite-registration-part-on'>
+                      <span class='star'>★</span> <span class='favorite-text'>気になるリストに追加</span>
+                    </div>
+                  <% end %>
+                <% end %>
+              <% end %>
+            </div>
+          </div>
+        </div>

--- a/app/views/pets/_pet_list.html.erb
+++ b/app/views/pets/_pet_list.html.erb
@@ -1,5 +1,9 @@
-<div class="row">
-  <% @pets.each do |pet| %>
-      <%= render partial: 'pets/pet_card', locals: { pet: pet } %>
-  <% end %>
-</div>
+<% if @pets.empty? %>
+  <h2>現在掲載中の募集はありません。</h2>
+<% else %>
+  <div class="row">
+    <% @pets.each do |pet| %>
+        <%= render partial: 'pets/pet_card', locals: { pet: pet } %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/pets/_pet_list.html.erb
+++ b/app/views/pets/_pet_list.html.erb
@@ -1,0 +1,5 @@
+<div class="row">
+  <% @pets.each do |pet| %>
+      <%= render partial: 'pets/pet_card', locals: { pet: pet } %>
+  <% end %>
+</div>

--- a/app/views/pets/index.html.erb
+++ b/app/views/pets/index.html.erb
@@ -26,7 +26,7 @@
   <% end %>
   <% if @show_more_link %>
     <div class="mt-3">
-      <p><%= link_to 'もっと見る', pets_path(all: true,user_id: params[:user_id]), class: 'btn btn-secondary' %></p>
+      <p><%= link_to 'もっと見る', members_pets_path(all: true,user_id: params[:user_id]), class: 'btn btn-secondary' %></p>
     </div>
   <% end %>
 </div>

--- a/app/views/pets/index.html.erb
+++ b/app/views/pets/index.html.erb
@@ -1,32 +1,5 @@
 <h1>掲載中の里親募集</h1>
 
 <div class="container">
-  <% if @pets.empty? %>
-    <h2>現在掲載中の募集はありません。</h2>
-  <% else %>
-    <div class="row">
-      <% @pets.each do |pet| %>
-        <div class="col-3">
-
-          <div class="card my-2">
-            <% if pet.pet_images.present? %>
-              <%= image_tag pet.pet_images.first.photo.to_s, class: 'card-img-top' %>
-            <% end %>
-            <div class="card-body">
-              <h5 class="card-title"><%= pet.petname %></h5>
-              <p><%= pet.classification_i18n %>/<%= pet.age %>才/<%= pet.gender_i18n %></p>
-              <h5 class="card-title">譲渡可能地域</h5>
-              <p class="card-text"><%= pet.introduction %></p>
-              <%= link_to 'ペット詳細情報を確認', pet_path(pet.id), class: "btn btn-primary" %>
-            </div>
-          </div>
-        </div>
-      <% end %>
-    </div>
-  <% end %>
-  <% if @show_more_link %>
-    <div class="mt-3">
-      <p><%= link_to 'もっと見る', members_pets_path(all: true,user_id: params[:user_id]), class: 'btn btn-secondary' %></p>
-    </div>
-  <% end %>
+  <%= render 'pets/pet_list', locals: { pets: @pets }%>
 </div>

--- a/app/views/pets/index.html.erb
+++ b/app/views/pets/index.html.erb
@@ -2,4 +2,5 @@
 
 <div class="container">
   <%= render 'pets/pet_list', locals: { pets: @pets }%>
+  <%= paginate @pets, theme: 'bootstrap-5' %>
 </div>

--- a/app/views/pets/index.html.erb
+++ b/app/views/pets/index.html.erb
@@ -1,6 +1,0 @@
-<h1>掲載中の里親募集</h1>
-
-<div class="container">
-  <%= render 'pets/pet_list', locals: { pets: @pets }%>
-  <%= paginate @pets, theme: 'bootstrap-5' %>
-</div>

--- a/app/views/pets/index.html.erb
+++ b/app/views/pets/index.html.erb
@@ -1,25 +1,32 @@
-<h1>Pets#index</h1>
-<p>Find me in app/views/pets/index.html.erb</p>
-<h2>掲載中の里親募集</h2>
+<h1>掲載中の里親募集</h1>
 
 <div class="container">
-  <div class="row">
-    <% @pets.each do |pet| %>
-      <div class="col-4">
+  <% if @pets.empty? %>
+    <h2>現在掲載中の募集はありません。</h2>
+  <% else %>
+    <div class="row">
+      <% @pets.each do |pet| %>
+        <div class="col-3">
 
-        <div class="card my-2">
-          <% if pet.pet_images.present? %>
-            <%= image_tag pet.pet_images.first.photo.to_s, class: 'card-img-top' %>
-          <% end %>
-          <div class="card-body">
-            <h5 class="card-title"><%= pet.petname %></h5>
-            <p><%= pet.classification_i18n %>/<%= pet.age %>才/<%= pet.gender_i18n %></p>
-            <h5 class="card-title">譲渡可能地域</h5>
-            <p class="card-text"><%= pet.introduction %></p>
-            <%= link_to 'ペット詳細情報を確認', pet_path(pet.id), class: "btn btn-primary" %>
+          <div class="card my-2">
+            <% if pet.pet_images.present? %>
+              <%= image_tag pet.pet_images.first.photo.to_s, class: 'card-img-top' %>
+            <% end %>
+            <div class="card-body">
+              <h5 class="card-title"><%= pet.petname %></h5>
+              <p><%= pet.classification_i18n %>/<%= pet.age %>才/<%= pet.gender_i18n %></p>
+              <h5 class="card-title">譲渡可能地域</h5>
+              <p class="card-text"><%= pet.introduction %></p>
+              <%= link_to 'ペット詳細情報を確認', pet_path(pet.id), class: "btn btn-primary" %>
+            </div>
           </div>
         </div>
-      </div>
-    <% end %>
-  </div>
+      <% end %>
+    </div>
+  <% end %>
+  <% if @show_more_link %>
+    <div class="mt-3">
+      <p><%= link_to 'もっと見る', pets_path(all: true,user_id: params[:user_id]), class: 'btn btn-secondary' %></p>
+    </div>
+  <% end %>
 </div>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -36,7 +36,7 @@
           <div class="card mb-4 p-3">
             <div class="d-flex justify-content-between">
         <div class="d-flex align-items-center"> 
-              <p><%= link_to message.user.profile.name, members_path(user_id: message.user.id) %></p>
+              <p><%= link_to message.user.profile.name, members_pets_path(user_id: message.user.id) %></p>
               <p>
               <!-- 自分のメッセージであるかのチェック -->
               <% if current_user == message.user %>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -36,7 +36,7 @@
           <div class="card mb-4 p-3">
             <div class="d-flex justify-content-between">
         <div class="d-flex align-items-center"> 
-              <p><%= link_to message.user.profile.name, pets_path(user_id: message.user.id) %></p>
+              <p><%= link_to message.user.profile.name, members_path(user_id: message.user.id) %></p>
               <p>
               <!-- 自分のメッセージであるかのチェック -->
               <% if current_user == message.user %>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -36,7 +36,7 @@
           <div class="card mb-4 p-3">
             <div class="d-flex justify-content-between">
         <div class="d-flex align-items-center"> 
-              <p><%= message.user.profile.name %></p>
+              <p><%= link_to message.user.profile.name, pets_path(user_id: message.user.id) %></p>
               <p>
               <!-- 自分のメッセージであるかのチェック -->
               <% if current_user == message.user %>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -36,7 +36,7 @@
           <div class="card mb-4 p-3">
             <div class="d-flex justify-content-between">
         <div class="d-flex align-items-center"> 
-              <p><%= link_to message.user.profile.name, members_pets_path(user_id: message.user.id) %></p>
+              <p><%= link_to message.user.profile.name, member_path(id: message.user.id) %></p>
               <p>
               <!-- 自分のメッセージであるかのチェック -->
               <% if current_user == message.user %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,11 +31,7 @@ Rails.application.routes.draw do
   end
   resources :messages, only: [:edit, :update, :destroy]
 
-  resources :users, as: :members, controller: 'members', path: 'members', only: [:show] do
-    member do
-      get 'pets', to: 'pets#index', as: 'pets'
-    end
+  resources :members, only: [:show] do
+    resources :pets, only: %i[index], module: :members
   end
-
-
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
     get 'users/sign_up/complete', to: 'users/registrations#complete'
   end
 
-  resources :pets do
+  resources :pets, except: [:index] do
     resource :favorites, only: [:create, :destroy]
     resource :rooms, only: [:create, :show]
   end
@@ -31,6 +31,11 @@ Rails.application.routes.draw do
   end
   resources :messages, only: [:edit, :update, :destroy]
 
-  get 'members/pets', to: 'members#index', as: 'members_pets'
+  resources :users, as: :members, controller: 'members', path: 'members', only: [:show] do
+    member do
+      get 'pets', to: 'pets#index', as: 'pets'
+    end
+  end
+
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,4 +30,6 @@ Rails.application.routes.draw do
     resources :messages, only: [:index,:new, :create]
   end
   resources :messages, only: [:edit, :update, :destroy]
+
+  resources :members, only: [:index]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,5 +31,6 @@ Rails.application.routes.draw do
   end
   resources :messages, only: [:edit, :update, :destroy]
 
-  resources :members, only: [:index]
+  get 'members/pets', to: 'members#index', as: 'members_pets'
+
 end

--- a/spec/controllers/members_controller_spec.rb
+++ b/spec/controllers/members_controller_spec.rb
@@ -1,45 +1,34 @@
 require 'rails_helper'
 
 RSpec.describe MembersController, type: :controller do
-  describe '#index' do
+  describe '#show' do  # ここを#showに変更
     let(:owned_user) { create(:user, &:confirm) }
     let!(:pets) { create_list(:pet, 5, user: owned_user) }
 
     before do
       sign_in owned_user
-      allow(controller).to receive(:params).and_return(params)
     end
 
     context '全てのペットを取得する場合' do
-      let(:params) { { user_id: owned_user.id, all: 'true' } }
-
       before do
-        get :index
+        get :show, params: { id: owned_user.id }
       end
 
       it '正常にレスポンスを返すこと' do
         expect(response).to be_successful
       end
-
-      it '全てのペットを@petsに格納する' do
-        expect(assigns(:pets).count).to eq 5
-      end
-
-      it '@show_more_linkはfalseである' do
-        expect(assigns(:show_more_link)).to be false
-      end
     end
 
     context 'ペットを4つまで取得する場合' do
-      let(:params) { { user_id: owned_user.id } }
+      before do
+        get :show, params: { id: owned_user.id }
+      end
 
       it '@petsには4つのペットが格納される' do
-        get :index
         expect(assigns(:pets).count).to eq 4
       end
 
       it '@show_more_linkはtrueである' do
-        get :index
         expect(assigns(:show_more_link)).to be true
       end
     end

--- a/spec/controllers/members_controller_spec.rb
+++ b/spec/controllers/members_controller_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe MembersController, type: :controller do
+  describe '#index' do
+    let(:owned_user) { create(:user, &:confirm) }
+    let!(:pets) { create_list(:pet, 5, user: owned_user) }
+
+    before do
+      sign_in owned_user
+      allow(controller).to receive(:params).and_return(params)
+    end
+
+    context '全てのペットを取得する場合' do
+      let(:params) { { user_id: owned_user.id, all: 'true' } }
+
+      before do
+        get :index
+      end
+
+      it '正常にレスポンスを返すこと' do
+        expect(response).to be_successful
+      end
+
+      it '全てのペットを@petsに格納する' do
+        expect(assigns(:pets).count).to eq 5
+      end
+
+      it '@show_more_linkはfalseである' do
+        expect(assigns(:show_more_link)).to be false
+      end
+    end
+
+    context 'ペットを4つまで取得する場合' do
+      let(:params) { { user_id: owned_user.id } }
+
+      it '@petsには4つのペットが格納される' do
+        get :index
+        expect(assigns(:pets).count).to eq 4
+      end
+
+      it '@show_more_linkはtrueである' do
+        get :index
+        expect(assigns(:show_more_link)).to be true
+      end
+    end
+  end
+end

--- a/spec/controllers/members_controller_spec.rb
+++ b/spec/controllers/members_controller_spec.rb
@@ -1,35 +1,60 @@
 require 'rails_helper'
 
 RSpec.describe MembersController, type: :controller do
-  describe '#show' do  # ここを#showに変更
-    let(:owned_user) { create(:user, &:confirm) }
-    let!(:pets) { create_list(:pet, 5, user: owned_user) }
+  describe '#show' do
+    describe '@show_more_linkがtrueの場合' do
+      let(:owned_user) { create(:user, &:confirm) }
+      let!(:pets) { create_list(:pet, 5, user: owned_user) }
 
-    before do
-      sign_in owned_user
+      before do
+        sign_in owned_user
+      end
+
+      context '全てのペットを取得する場合' do
+        before do
+          get :show, params: { id: owned_user.id }
+        end
+
+        it '正常にレスポンスを返すこと' do
+          expect(response).to be_successful
+        end
+      end
+
+      context 'ペットを4つまで取得する場合' do
+        before do
+          get :show, params: { id: owned_user.id }
+        end
+
+        it '@petsには4つのペットが格納される' do
+          expect(assigns(:pets).count).to eq 4
+        end
+
+        it '@show_more_linkはtrueである' do
+          expect(assigns(:show_more_link)).to be true
+        end
+      end
     end
 
-    context '全てのペットを取得する場合' do
+    describe '@show_more_linkがfalse(ペットが3つ)の場合' do
+      let(:owned_user) { create(:user, &:confirm) }
+      let!(:pets) { create_list(:pet, 3, user: owned_user) }
+
       before do
-        get :show, params: { id: owned_user.id }
+        sign_in owned_user
       end
 
-      it '正常にレスポンスを返すこと' do
-        expect(response).to be_successful
-      end
-    end
+      context 'ペットを3つまで取得する場合' do
+        before do
+          get :show, params: { id: owned_user.id }
+        end
 
-    context 'ペットを4つまで取得する場合' do
-      before do
-        get :show, params: { id: owned_user.id }
-      end
+        it '@petsには3つのペットが格納される' do
+          expect(assigns(:pets).count).to eq 3
+        end
 
-      it '@petsには4つのペットが格納される' do
-        expect(assigns(:pets).count).to eq 4
-      end
-
-      it '@show_more_linkはtrueである' do
-        expect(assigns(:show_more_link)).to be true
+        it '@show_more_linkはfalseである' do
+          expect(assigns(:show_more_link)).to be false
+        end
       end
     end
   end

--- a/spec/features/members_index_spec.rb
+++ b/spec/features/members_index_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature 'members/index', type: :feature do
 
     before do
       sign_in joined_user
-      visit members_pets_path(user_id: joined_user.id)
+      visit member_path(id: joined_user.id)
     end
 
       it "現在掲載中の募集はありませんが表示される" do
@@ -28,7 +28,7 @@ RSpec.feature 'members/index', type: :feature do
   describe '掲載中の募集がある場合' do
     before do
       sign_in joined_user
-      visit members_pets_path(user_id: owned_user.id)
+      visit member_path(id: owned_user.id)
     end
 
     context 'ペットが4つ未満の場合' do
@@ -40,16 +40,11 @@ RSpec.feature 'members/index', type: :feature do
     context 'ペットが4つ以上の場合' do
       before do
         create(:pet, user: owned_user) #ペットを追加し、登録数5にする
-        visit members_pets_path(user_id: owned_user.id)
+        visit member_path(id: owned_user.id)
       end
 
       scenario 'もっと見るリンクが表示されていること' do
         expect(page).to have_content("もっと見る")
-      end
-
-      scenario 'もっと見るリンクを押すともっと見るが消える' do
-        click_link 'もっと見る'
-        expect(page).not_to have_content("もっと見る")
       end
     end
   end

--- a/spec/features/members_index_spec.rb
+++ b/spec/features/members_index_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.feature 'members/index', type: :feature do
+  let!(:owned_user) { create(:user, &:confirm) }
+  let!(:joined_user) { create(:user, &:confirm) }
+  let!(:pets) { create_list(:pet, 4, user: owned_user) }
+
+  let!(:joined_room) do
+    room = create(:room, user: joined_user, owner: owned_user, pet: pets.first)
+      create(:message, room: room, user: joined_user, body: "テストメッセージ")
+      create(:message, room: room, user: owned_user, body: "オーナーからの返信")
+    room
+  end
+
+
+  describe '掲載中の募集がない場合' do
+
+    before do
+      sign_in joined_user
+      visit members_pets_path(user_id: joined_user.id)
+    end
+
+      it "現在掲載中の募集はありませんが表示される" do
+        expect(page).to have_content("現在掲載中の募集はありません。")
+      end
+  end
+
+  describe '掲載中の募集がある場合' do
+    before do
+      sign_in joined_user
+      visit members_pets_path(user_id: owned_user.id)
+    end
+
+    context 'ペットが4つ未満の場合' do
+      scenario 'もっと見るリンクが表示されていないこと' do
+        expect(page).not_to have_content("もっと見る")
+      end
+    end
+
+    context 'ペットが4つ以上の場合' do
+      before do
+        create(:pet, user: owned_user) #ペットを追加し、登録数5にする
+        visit members_pets_path(user_id: owned_user.id)
+      end
+
+      scenario 'もっと見るリンクが表示されていること' do
+        expect(page).to have_content("もっと見る")
+      end
+
+      scenario 'もっと見るリンクを押すともっと見るが消える' do
+        click_link 'もっと見る'
+        expect(page).not_to have_content("もっと見る")
+      end
+    end
+  end
+
+
+
+
+end


### PR DESCRIPTION
## 概要
他ユーザーのユーザーページを作成する。
メッセージ詳細のユーザー名からユーザーページに遷移できることとする。

## 完了条件
デザインに沿ってユーザーページがコーディングされていること
募集中の里親がある場合は4件まで表示されていること
募集中の里親が4件以上ある場合は「もっと見る」のリンクが表示され、一覧画面に遷移できること
メッセージ詳細のユーザー名からユーザーページに遷移できること
関連するテストが追加され、全てパスしていること