### PR TITLE
プロフィール編集時の挙動を修正 #19

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -9,10 +9,10 @@ class ProfilesController < ApplicationController
 
     if @user.update(user_params)
       flash[:notice] = "更新しました。"
-      redirect_to users_path
+      redirect_to edit_users_path
     else
-      flash[:alert] = "更新できませんでした。"
-      render 'users/edit'
+      flash[:alert] = "更新できませんでした: " + @user.errors.full_messages.join(', ')
+      redirect_to edit_users_path
     end
   end
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -39,26 +39,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # PUT /resource
   def update
     if params[:user][:current_password].present?
-      self.resource = resource_class.to_adapter.get!(send(:"current_#{resource_name}").to_key)
-      prev_unconfirmed_email = resource.unconfirmed_email if resource.respond_to?(:unconfirmed_email)
-
-      resource_updated = update_resource(resource, account_update_params)
-      yield resource if block_given?
-      if resource_updated
-        set_flash_message_for_update(resource, prev_unconfirmed_email)
-        bypass_sign_in resource, scope: resource_name if sign_in_after_change_password?
-
-        # 更新が成功した場合のリダイレクト先を設定
-        respond_with resource, location: edit_users_path
-      else
-        clean_up_passwords resource
-        set_minimum_password_length
-        # 更新が失敗した場合もedit_users_pathにリダイレクト
-        flash[:alert] = '更新できませんでした: ' + resource.errors.full_messages.join(', ')
-        redirect_to edit_users_path
-      end
+      super
     else
-      flash[:alert] = '変更する場合は現在のパスワードを入力してください。'
+      flash[:alert] = "更新できませんでした: " + @user.errors.full_messages.join(', ')
       redirect_to edit_users_path
     end
   end
@@ -106,6 +89,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   def account_update_params
     params.require(:user).permit(:email, :password, :password_confirmation, :current_password)
+  end
+
+  def after_update_path_for(resource)
+    edit_users_path
   end
 
   private

--- a/spec/controllers/profiles_controller_spec.rb
+++ b/spec/controllers/profiles_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ProfilesController, type: :controller do
       it '正しく値が設定された場合ユーザーのマイページ画面が描画されること' do
         profile_params = attributes_for(:profile)
         put :update, params: { user: { profile_attributes: profile_params } }
-        expect(response).to redirect_to users_path
+        expect(response).to redirect_to edit_users_path
       end
 
       it '正しく値が設定された場合ユーザーの情報が更新されていること' do
@@ -33,10 +33,10 @@ RSpec.describe ProfilesController, type: :controller do
       end
     end
     context '異常系' do
-      it '正しく値が設定されなかった場合、登録情報編集画面が描画されること' do
+      it '正しく値が設定されなかった場合、登録情報編集画面にリダイレクトされること' do
         profile_params = attributes_for(:profile, name: nil, user_id: @user.id)
         put :update, params: { id: @user, user: { profile_attributes: profile_params } }
-        expect(response).to render_template 'users/edit'
+        expect(response).to redirect_to edit_users_path
       end
     end
   end

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe Users::RegistrationsController, type: :controller do
       it '正しく値が設定されなかった場合、flash メッセージが正しく表示されること' do
         user_params = attributes_for(:user, email: user.email, current_password: nil )
         put :update, params: { user: user_params }
-        expect(flash[:alert]).to eq '更新できませんでした: '
+        expect(flash[:alert]).to eq '更新できませんでした: ' + user.errors.full_messages.join(', ')
       end
     end
   end

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -120,9 +120,8 @@ RSpec.describe Users::RegistrationsController, type: :controller do
       it '正しく値が設定されなかった場合、flash メッセージが正しく表示されること' do
         user_params = attributes_for(:user, email: user.email, current_password: nil )
         put :update, params: { user: user_params }
-        expect(flash[:alert]).to eq '変更する場合は現在のパスワードを入力してください。'
+        expect(flash[:alert]).to eq '更新できませんでした: '
       end
     end
-
   end
 end

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Users::RegistrationsController, type: :controller do
       it '正しく値が設定された場合、Home 画面が描画されること' do
         user_params = attributes_for(:user, email: user.email, password:'password',password_confirmation: 'password', current_password: 'password12345' )
         put :update, params: { user: user_params }
-        expect(response).to redirect_to root_path
+        expect(response).to redirect_to edit_users_path
       end
 
       it '正しく値が設定された場合(パスワード)、flash メッセージが正しく表示されること' do
@@ -114,7 +114,7 @@ RSpec.describe Users::RegistrationsController, type: :controller do
       it '正しく値が設定されなかった場合、登録情報編集画面が描画されること' do
         user_params = attributes_for(:user, email: user.email, current_password: nil )
         put :update, params: { user: user_params }
-        expect(response).to render_template :edit
+        expect(response).to redirect_to edit_users_path
       end
 
       it '正しく値が設定されなかった場合、flash メッセージが正しく表示されること' do

--- a/spec/features/user_edit_spec.rb
+++ b/spec/features/user_edit_spec.rb
@@ -95,7 +95,7 @@ RSpec.feature '会員情報編集', type: :feature do
         fill_in 'パスワード', with: nil
         fill_in 'パスワード（確認用）', with: nil
         click_button 'アカウント情報更新'
-        expect(page).to have_content '変更する場合は現在のパスワードを入力してください。'
+        expect(page).to have_content '更新できませんでした'
       end
 
       scenario '現在のパスワードを入力し、email を入力しなかった場合、バリデーションエラーの内容が表示されること' do

--- a/spec/features/user_edit_spec.rb
+++ b/spec/features/user_edit_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature '会員情報編集', type: :feature do
           fill_in '生年月日', with: '2022-06-26'
           fill_in '飼主経験', with: '猫1年'
           click_button 'プロフィール内容変更'
-          expect(page).to have_current_path users_path
+          expect(page).to have_current_path edit_users_path
         end
       end
 
@@ -81,7 +81,7 @@ RSpec.feature '会員情報編集', type: :feature do
         click_button 'アカウント情報更新'
       end
       scenario 'アカウント情報を正しく入力した場合、Home 画面に遷移すること' do
-        expect(page).to have_current_path root_path
+        expect(page).to have_current_path edit_users_path
       end
       scenario 'アカウント情報を正しく入力した場合、flash メッセージが正しく表示されること' do
         expect(page).to have_content 'アカウント情報を変更しました。'


### PR DESCRIPTION
## 概要
  プロフィール編集時の挙動を修正する。

## 完了条件
- プロフィール編集成功時、編集画面が再描画され編集完了を伝える flash メッセージが表示されていること
- アカウント編集成功時、編集画面が再描画され編集完了を伝える flash メッセージが表示されていること
- プロフィール編集失敗時、編集画面が再描画されバリデーションエラーが表示されていること
- アカウント編集失敗時、編集画面が再描画されバリデーションエラーが表示されていること
現在のパスワードを空でアカウント編集を行おうとした場合フォームの必須エラーに引っかかること


