### PR TITLE
Issue #76 管理画面のユーザー詳細画面を作成する

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -2,3 +2,4 @@
 @import 'bootstrap-icons/font/bootstrap-icons';
 @import 'shared/header';
 @import 'shared/main';
+@import 'shared/admin_main';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,4 +16,4 @@
 
 @import 'bootstrap/scss/bootstrap';
 @import 'bootstrap-icons/font/bootstrap-icons';
-@import 'shared/header'
+@import 'shared'

--- a/app/assets/stylesheets/shared/admin_main.scss
+++ b/app/assets/stylesheets/shared/admin_main.scss
@@ -1,0 +1,3 @@
+.table-bordered-dark {
+  border: 2px solid #caced1;
+}

--- a/app/controllers/admins/users_controller.rb
+++ b/app/controllers/admins/users_controller.rb
@@ -5,6 +5,10 @@ class Admins::UsersController < ApplicationController
     @users = User.includes(%i[profile pets]).page(params[:page]).per(20)
   end
 
+  def show
+    @user = User.includes(%i[profile pets]).find(params[:id])
+  end
+
   def destroy
     @user = User.find(params[:id])
     if @user.destroy

--- a/app/controllers/admins/users_controller.rb
+++ b/app/controllers/admins/users_controller.rb
@@ -1,20 +1,24 @@
 class Admins::UsersController < ApplicationController
   before_action :authenticate_admin!
+  before_action :set_user, only: %i[show destroy]
 
   def index
     @users = User.includes(%i[profile pets]).page(params[:page]).per(20)
   end
 
-  def show
-    @user = User.includes(%i[profile pets]).find(params[:id])
-  end
+  def show; end
 
   def destroy
-    @user = User.find(params[:id])
     if @user.destroy
       redirect_to admins_users_path, notice: 'ユーザーが削除されました。'
     else
       redirect_to admins_users_path, alert: 'ユーザー削除に失敗しました。'
     end
+  end
+
+  private
+
+  def set_user
+    @user = User.find(params[:id])
   end
 end

--- a/app/views/admins/users/index.html.erb
+++ b/app/views/admins/users/index.html.erb
@@ -35,7 +35,7 @@
             <td><%= user.created_at.strftime('%Y-%m-%d %H:%M:%S') %></td>
             <td><%= user.pets.size %></td>
             <td class="d-flex justify-content-between">
-              <%= link_to '詳細', '#', class: "btn btn-warning" %>
+              <%= link_to '詳細', admins_user_path(user.id), class: "btn btn-warning" %>
               <%= link_to '削除', admins_user_path(user.id), class: "btn btn-danger", data: { turbo_method: :delete, turbo_confirm: '本当に削除してよろしいですか？' } %>
             </td>
           </tr>

--- a/app/views/admins/users/index.html.erb
+++ b/app/views/admins/users/index.html.erb
@@ -35,7 +35,7 @@
             <td><%= user.created_at.strftime('%Y-%m-%d %H:%M:%S') %></td>
             <td><%= user.pets.size %></td>
             <td class="d-flex justify-content-between">
-              <%= link_to '詳細', admins_user_path(user.id), class: "btn btn-warning" %>
+              <%= link_to '詳細', admins_user_path(user.id, page: params[:page]), class: "btn btn-warning" %>
               <%= link_to '削除', admins_user_path(user.id), class: "btn btn-danger", data: { turbo_method: :delete, turbo_confirm: '本当に削除してよろしいですか？' } %>
             </td>
           </tr>

--- a/app/views/admins/users/show.html.erb
+++ b/app/views/admins/users/show.html.erb
@@ -1,5 +1,5 @@
 <div class="container mt-5">
-  <%= link_to '<戻る', admins_users_path, class: 'btn btn-light mb-3' %>
+  <%= link_to '<戻る', admins_users_path(page: params[:page]), class: 'btn btn-light mb-3' %>
 
   <h1 class="mb-4">ユーザー詳細</h1>
 

--- a/app/views/admins/users/show.html.erb
+++ b/app/views/admins/users/show.html.erb
@@ -1,0 +1,42 @@
+<div class="container mt-5">
+  <%= link_to '<戻る', admins_users_path, class: 'btn btn-light mb-3' %>
+
+  <h1 class="mb-4">ユーザー詳細</h1>
+
+  <div class="card shadow-lg">
+    <div class="card-body">
+      <table class="table table-bordered-dark">
+        <tbody>
+          <tr>
+            <th class="bg-light">氏名</th>
+            <td><%= @user.profile.name %></td>
+          </tr>
+          <tr>
+            <th class="bg-light">ご住所</th>
+            <td><%= @user.profile.address %></td>
+          </tr>
+          <tr>
+            <th class="bg-light">電話番号</th>
+            <td><%= @user.profile.phone_number %></td>
+          </tr>
+          <tr>
+            <th class="bg-light">生年月日</th>
+            <td><%= @user.profile.birthday.strftime('%Y年%m月%d日') %></td>
+          </tr>
+          <tr>
+            <th class="bg-light">飼い主経験</th>
+            <td><%= @user.profile.breeding_experience %></td>
+          </tr>
+          <tr>
+            <th class="bg-light">登録日時</th>
+            <td><%= @user.profile.created_at.strftime('%Y年%m月%d日 %H:%M:%S') %></td>
+          </tr>
+          <tr>
+            <th class="bg-light">里親募集</th>
+            <td><%= @user.pets.size %> 件</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
 
   namespace :admins do
     root 'home#index'
-    resources :users, only: [:index,:destroy]
+    resources :users, only: [:index,:destroy,:show]
     delete 'sign_out', to: 'sessions#destroy', as: :destroy_admin_session
   end
 

--- a/spec/controllers/admins/users_controller_spec.rb
+++ b/spec/controllers/admins/users_controller_spec.rb
@@ -44,4 +44,18 @@ RSpec.describe Admins::UsersController, type: :controller do
       end
     end
   end
+
+  describe 'GET #show' do
+    context '指定されたユーザーの詳細を表示' do
+      before { get :show, params: { id: user.id } }
+
+      it 'リクエストされたユーザーが@userに割り当てられていること' do
+        expect(assigns(:user)).to eq(user)
+      end
+
+      it 'showテンプレートがレンダリングされていること' do
+        expect(response).to render_template :show
+      end
+    end
+  end
 end

--- a/spec/features/admins/admin_users_show_spec.rb
+++ b/spec/features/admins/admin_users_show_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.feature 'admins/users/index', type: :feature do
+  let(:admin) { create(:admin) }
+  let!(:user) { create(:user, &:confirm) }
+  let!(:pet) { create(:pet, user_id: user.id) }
+
+  before do
+    sign_in admin
+    visit admins_users_path
+    click_link '詳細'
+  end
+
+  scenario 'ユーザー詳細ページを表示する' do
+    expect(page).to have_content('ユーザー詳細')
+  end
+
+  scenario 'プロフィール詳細が表示されていること' do
+    expect(page).to have_content user.profile.name
+    expect(page).to have_content user.profile.address
+    expect(page).to have_content user.profile.phone_number
+    expect(page).to have_content user.profile.birthday.strftime('%Y年%m月%d日')
+    expect(page).to have_content user.profile.breeding_experience
+    expect(page).to have_content user.profile.created_at.strftime('%Y年%m月%d日 %H:%M:%S')
+    expect(page).to have_content "#{user.pets.size} 件"
+  end
+end


### PR DESCRIPTION
## 実装内容
管理画面のユーザー詳細画面を作成する
ユーザー一覧から遷移ができるようにする

## 完了条件
管理画面のユーザー一覧から遷移ができること
デザインに沿ってコーディングがされていること
関連するテストを全てパスしていること