### PR TITLE
 Issue #78 管理画面の里親募集詳細画面を作成する

### DIFF
--- a/app/controllers/admins/pets_controller.rb
+++ b/app/controllers/admins/pets_controller.rb
@@ -1,10 +1,12 @@
 class Admins::PetsController < ApplicationController
   before_action :authenticate_admin!
-  before_action :set_pet, only: %i[destroy]
+  before_action :set_pet, only: %i[destroy show]
 
   def index
     @pets = Pet.includes(user: :profile, pet_images: []).page(params[:page]).per(20)
   end
+
+  def show; end
 
   def destroy
     if @pet.destroy

--- a/app/views/admins/pets/index.html.erb
+++ b/app/views/admins/pets/index.html.erb
@@ -31,7 +31,7 @@
             <td><%= pet.user.profile.name %></td>
             <td><%= pet.created_at.strftime('%Y-%m-%d %H:%M:%S') %></td>
             <td class="d-flex justify-content-between">
-              <%= link_to '詳細', '#', class: "btn btn-warning" %>
+              <%= link_to '詳細', admins_pet_path(pet.id, page: params[:page]), class: "btn btn-warning" %>
               <%= link_to '削除', admins_pet_path(pet.id), class: "btn btn-danger", data: { turbo_method: :delete, turbo_confirm: '本当に削除してよろしいですか？' } %>
             </td>
           </tr>

--- a/app/views/admins/pets/show.html.erb
+++ b/app/views/admins/pets/show.html.erb
@@ -1,0 +1,55 @@
+<div class="container mt-5">
+  <%= link_to '<戻る', admins_pets_path(page: params[:page]), class: 'btn btn-light mb-3' %>
+
+  <h1 class="mb-4">里親募集詳細</h1>
+
+  <div class="card shadow-lg">
+    <div class="card-body">
+      <table class="table table-bordered-dark">
+        <tbody>
+          <tr>
+            <th class="bg-light">画像</th>
+            <td>
+              <% @pet.pet_images.each do |image| %>
+                <%= image_tag image.photo.to_s, class: "img-thumbnail-h60" %>
+              <% end %>
+            </td>
+          </tr>
+          <tr>
+            <th class="bg-light">名前</th>
+            <td><%= @pet.petname %></td>
+          </tr>
+          <tr>
+            <th class="bg-light">カテゴリ</th>
+            <td><%= @pet.category_i18n %></td>
+          </tr>
+          <tr>
+            <th class="bg-light">ユーザー</th>
+            <td><%= @pet.user.profile.name %></td>
+          </tr>
+          <tr>
+            <th class="bg-light">性別</th>
+            <td><%= @pet.gender_i18n %></td>
+          </tr>
+          <tr>
+            <th class="bg-light">年齢</th>
+            <td><%= @pet.age %>才</td>
+          </tr>
+          <tr>
+            <th class="bg-light">種類</th>
+            <td><%= @pet.classification_i18n %></td>
+          </tr>
+            <th class="bg-light">性格</th>
+            <td><%= @pet.introduction %></td>
+          </tr>
+          <tr>
+            <th class="bg-light">登録日時</th>
+            <td><%= @pet.created_at.strftime('%Y年%m月%d日 %H:%M:%S') %></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+   <%= link_to 'ピックアップ追加', '#',  data: { turbo_method: :get }, class: "btn btn to_owner_send_mail mt-2" %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ Rails.application.routes.draw do
   namespace :admins do
     root 'home#index'
     resources :users, only: [:index,:destroy,:show]
-    resources :pets, only: [:index,:destroy]
+    resources :pets, only: [:index,:destroy,:show]
     delete 'sign_out', to: 'sessions#destroy', as: :destroy_admin_session
   end
 

--- a/spec/controllers/admins/pets_controller_spec.rb
+++ b/spec/controllers/admins/pets_controller_spec.rb
@@ -27,16 +27,30 @@ RSpec.describe Admins::PetsController, type: :controller do
       end
     end
 
-    context 'ユーザーが削除できなかった場合' do
+    context 'ペットが削除できなかった場合' do
       before do
-        # Userモデルのdestroyメソッドがfalseを返すようにする
+        # Petモデルのdestroyメソッドがfalseを返すようにする
         allow_any_instance_of(Pet).to receive(:destroy).and_return(false)
       end
 
-      it 'ユーザー一覧にリダイレクトし、正しいアラートが表示されること' do
+      it 'ペット一覧にリダイレクトし、正しいアラートが表示されること' do
         delete :destroy, params: { id: pet.id }
         expect(response).to redirect_to(admins_pets_path)
         expect(flash[:alert]).to eq('ペット削除に失敗しました。')
+      end
+    end
+  end
+
+  describe 'GET #show' do
+    context '指定されたユーザーの詳細を表示' do
+      before { get :show, params: { id: pet.id } }
+
+      it 'リクエストされたユーザーが@petに割り当てられていること' do
+        expect(assigns(:pet)).to eq(pet)
+      end
+
+      it 'showテンプレートがレンダリングされていること' do
+        expect(response).to render_template :show
       end
     end
   end

--- a/spec/features/admins/admin_pets_index_spec.rb
+++ b/spec/features/admins/admin_pets_index_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature 'admins/pets/index', type: :feature do
       expect(page).to have_content(pet.created_at.strftime('%Y-%m-%d %H:%M:%S'))
     end
 
-    expect(page).to have_link('詳細', href: '#')
+    expect(page).to have_link('詳細', href: admins_pet_path(pet.id))
     expect(page).to have_link('削除', href: admins_pet_path(pet.id))
   end
 

--- a/spec/features/admins/admin_pets_show_spec.rb
+++ b/spec/features/admins/admin_pets_show_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.feature 'admins/pets/show', type: :feature do
+  let(:admin) { create(:admin) }
+  let!(:user) { create(:user, &:confirm) }
+  let!(:pet) { create(:pet, user:) }
+
+  before do
+    sign_in admin
+    visit admins_pets_path
+    click_link '詳細'
+  end
+
+  scenario 'ペット詳細ページを表示する' do
+    expect(page).to have_content('里親募集詳細')
+  end
+
+  scenario '里親募集詳細が表示されていること' do
+    within 'tbody' do
+      pet.pet_images.each do |image|
+        expect(page).to have_selector("img[src$='#{image.photo.url}']")
+      end
+      expect(page).to have_content pet.petname
+      expect(page).to have_content pet.category_i18n
+      expect(page).to have_content pet.user.profile.name
+      expect(page).to have_content pet.gender_i18n
+      expect(page).to have_content "#{pet.age}才"
+      expect(page).to have_content pet.classification_i18n
+      expect(page).to have_content pet.introduction
+      expect(page).to have_content pet.created_at.strftime('%Y年%m月%d日 %H:%M:%S')
+    end
+  end
+end

--- a/spec/features/admins/admin_users_show_spec.rb
+++ b/spec/features/admins/admin_users_show_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'admins/users/index', type: :feature do
+RSpec.feature 'admins/users/show', type: :feature do
   let(:admin) { create(:admin) }
   let!(:user) { create(:user, &:confirm) }
   let!(:pet) { create(:pet, user_id: user.id) }
@@ -24,4 +24,7 @@ RSpec.feature 'admins/users/index', type: :feature do
     expect(page).to have_content user.profile.created_at.strftime('%Y年%m月%d日 %H:%M:%S')
     expect(page).to have_content "#{user.pets.size} 件"
   end
+
+  expect(page).to have_link('詳細', href: admins_pet_path(pet.id))
+  expect(page).to have_link('削除', href: admins_pet_path(pet.id))
 end


### PR DESCRIPTION
## 実装内容
管理画面の里親募集詳細画面を作成する
里親募集一覧から遷移ができるようにする

## 完了条件
管理画面の里親募集一覧から遷移ができること
デザインに沿ってコーディングがされていること
関連するテストを全てパスしていること
