### PR TITLE
Issue #11 ヘッダーのレイアウト調整

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -3,3 +3,4 @@
 @import 'shared/header';
 @import 'shared/main';
 @import 'shared/admin_main';
+@import 'shared/footer';

--- a/app/assets/stylesheets/shared/footer.scss
+++ b/app/assets/stylesheets/shared/footer.scss
@@ -1,0 +1,17 @@
+.site-footer {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 50px;
+    background-color: #FFFBEE;
+    text-align: center;
+    padding-bottom: 80px; 
+    padding-top: 0;
+}
+
+.footer-container {
+  max-width: 850px;
+  margin: 0 auto; 
+  padding: 0 15px; 
+}

--- a/app/assets/stylesheets/shared/footer.scss
+++ b/app/assets/stylesheets/shared/footer.scss
@@ -6,12 +6,11 @@
     height: 50px;
     background-color: #FFFBEE;
     text-align: center;
-    padding-bottom: 80px; 
-    padding-top: 0;
+    padding: 0 0 80px; 
 }
 
 .footer-container {
-  max-width: 850px;
+  max-width: 950px;
   margin: 0 auto; 
   padding: 0 15px; 
 }

--- a/app/assets/stylesheets/shared/header.scss
+++ b/app/assets/stylesheets/shared/header.scss
@@ -1,3 +1,19 @@
+.header-container {
+  margin: 0;
+  background-color:  #FFFBEE;
+}
+
+
+.header-content {
+  max-width: 850px;
+  margin: 0 auto; /* 中央配置 */
+  padding: 0 15px; /* 必要に応じて左右の内側の余白を追加 */
+}
+
+.nav-divider {
+  margin: bottom 0; /* 必要に応じて余白を削除 */
+}
+
 .navbar {
     position: relative;
     display: flex;
@@ -20,12 +36,11 @@ a {
     margin: 10px;
 }
 
-
-.navbar-nav {
-    .nav-item  {
-        font-size: 20px;
-    }
+.navbar-nav .nav-link,
+.navbar-nav .nav-item {
+  font-size: 1rem;
 }
+
 
 
 //ダッシュボードのLink

--- a/app/assets/stylesheets/shared/header.scss
+++ b/app/assets/stylesheets/shared/header.scss
@@ -5,7 +5,7 @@
 
 
 .header-content {
-  max-width: 850px;
+  max-width: 950px;
   margin: 0 auto; /* 中央配置 */
   padding: 0 15px; /* 必要に応じて左右の内側の余白を追加 */
 }

--- a/app/assets/stylesheets/shared/main.scss
+++ b/app/assets/stylesheets/shared/main.scss
@@ -3,6 +3,10 @@ body {
   padding-top: 50px;
 }
 
+.main-content {
+  padding-top: 30px;
+}
+
 // サインアップtitle
 .form-signup-title {
   width: 100%;

--- a/app/assets/stylesheets/shared/main.scss
+++ b/app/assets/stylesheets/shared/main.scss
@@ -1,6 +1,7 @@
 body {
   background-color: #FFFBEE;
   padding-top: 50px;
+  padding-bottom: 60px; 
 }
 
 .main-content {
@@ -261,3 +262,4 @@ body {
 .img-thumbnail-h60 {
   max-height: 60px;
 }
+

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,14 +6,14 @@
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
   <%= stylesheet_link_tag 'application', "data-turbo-track": 'reload' %>
-    <%= javascript_importmap_tags %>
+  <%= javascript_importmap_tags %>
 </head>
 
-  <body>
-    <%= render 'layouts/shared/header' %>
-    <div class="mt-5">
-      <%= render 'layouts/shared/flash' %>
-      <%= yield %>
-    </div>
-  </body>
+<body>
+<%= render 'layouts/shared/header' %>
+<%= render 'layouts/shared/flash' %>
+<div class="main-content">
+  <%= yield %>
+</div>
+</body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,5 +15,6 @@
 <div class="main-content">
   <%= yield %>
 </div>
+<%= render 'layouts/shared/footer' %>
 </body>
 </html>

--- a/app/views/layouts/shared/_admins_header.html.erb
+++ b/app/views/layouts/shared/_admins_header.html.erb
@@ -1,19 +1,16 @@
-<header class="fixed-top">
-  <nav class="navbar navbar-expand navbar-light ">
-    <div class="container-fluid nab-color ">
-      <h1>ZeroWanApp 管理者画面</h1>
-      <ul class="nav navbar-nav navbar-right">
-        <% if admin_signed_in? %>
-          <li class="nav-item active">
-            <%= link_to '管理者ログアウト', destroy_admin_session_path, class: "nav-link", data: { turbo_method: :delete } %>
-          </li>
-        <% else %>
-          <li class="nav-item active">
-            <%= link_to '管理者ログイン', new_admin_session_path, class: "nav-link" %>
-          </li>
-        <% end %>
-      </ul>
-    </div>
-  </nav>
-  <hr class="nav-divider">
-</header>
+<nav class="navbar navbar-expand navbar-light ">
+  <div class="container-fluid nab-color ">
+    <h1>ZeroWanApp 管理者画面</h1>
+    <ul class="nav navbar-nav navbar-right">
+      <% if admin_signed_in? %>
+        <li class="nav-item active">
+          <%= link_to '管理者ログアウト', destroy_admin_session_path, class: "nav-link", data: { turbo_method: :delete } %>
+        </li>
+      <% else %>
+        <li class="nav-item active">
+          <%= link_to '管理者ログイン', new_admin_session_path, class: "nav-link" %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+</nav>

--- a/app/views/layouts/shared/_footer.html.erb
+++ b/app/views/layouts/shared/_footer.html.erb
@@ -1,0 +1,7 @@
+
+<footer class="site-footer">
+  <hr class="nav-divider">
+    <div class="footer-container">
+        <p>Copyright  &copy; 2022 ZeroWAnApp. All Rights Reserved.</p>
+    </div>
+</footer>

--- a/app/views/layouts/shared/_header.html.erb
+++ b/app/views/layouts/shared/_header.html.erb
@@ -1,5 +1,12 @@
-    <% if request.fullpath.include?('/admin') %>
-      <%= render 'layouts/shared/admins_header' %>
-    <% else %>
-      <%= render 'layouts/shared/users_header' %>
-    <% end %>
+<header class="fixed-top">
+  <div class="header-container">
+    <div class="header-content">
+      <% if request.fullpath.include?('/admin') %>
+        <%= render 'layouts/shared/admins_header' %>
+      <% else %>
+        <%= render 'layouts/shared/users_header' %>
+      <% end %>
+    </div>
+    <hr class="nav-divider">
+  </div>
+</header>

--- a/app/views/layouts/shared/_users_header.html.erb
+++ b/app/views/layouts/shared/_users_header.html.erb
@@ -1,32 +1,30 @@
-<header class="fixed-top">
-  <nav class="navbar navbar-expand navbar-light ">
-    <div class="container-fluid nab-color ">
-      <h1>ZeroWanApp</h1>
-      <ul class="nav navbar-nav navbar-right">
+<nav class="navbar navbar-expand navbar-light ">
+  <div class="container-fluid nab-color ">
+    <h1>ZeroWanApp</h1>
+    <ul class="nav navbar-nav navbar-right">
 
+      <li class="nav-item active">
+        <%= link_to 'トップ', root_path, class: "nav-link" %>
+      </li>
+      <li class="nav-item active">
+        <%= link_to 'このサイトについて', root_path, class: "nav-link" %>
+      </li>
+      <% if user_signed_in? %>
         <li class="nav-item active">
-          <%= link_to 'トップ', root_path, class: "nav-link" %>
+          <%= link_to 'マイページ', users_path, class: "nav-link" %>
         </li>
         <li class="nav-item active">
-          <%= link_to 'このサイトについて', root_path, class: "nav-link" %>
+          <%= link_to 'ログアウト', destroy_user_session_path, class: "nav-link", data: { turbo_method: :delete } %>
         </li>
-        <% if user_signed_in? %>
-          <li class="nav-item active">
-            <%= link_to 'マイページ', users_path, class: "nav-link" %>
-          </li>
-          <li class="nav-item active">
-            <%= link_to 'ログアウト', destroy_user_session_path, class: "nav-link", data: { turbo_method: :delete } %>
-          </li>
-        <% else %>
-          <li class="nav-item active">
-            <%= link_to '会員登録', new_user_registration_path, class: "nav-link" %>
-          </li>
-          <li class="nav-item active">
-            <%= link_to 'ログイン', new_user_session_path, class: "nav-link" %>
-          </li>
-        <% end %>
-      </ul>
-    </div>
-  </nav>
-  <hr class="nav-divider">
-</header>
+      <% else %>
+        <li class="nav-item active">
+          <%= link_to '会員登録', new_user_registration_path, class: "nav-link" %>
+        </li>
+        <li class="nav-item active">
+          <%= link_to 'ログイン', new_user_session_path, class: "nav-link" %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+</nav>
+


### PR DESCRIPTION
## 実装内容
ヘッダーのレイアウトを調整する。
調整項目は以下の通り。

タイトル、ナビゲーションを再大幅850px に収める
アンダーラインは画面幅いっぱいまで伸ばす（現状通り）
ナビゲーションのフォントサイズを小さくする（1rem で OK です）
スクロールするとメイン部分がヘッダーの線の内側に潜り込んでしまっているので潜り込まないようにする