### PR TITLE
# Issue #90 動作不具合修正

### DIFF
--- a/app/views/pets/edit.html.erb
+++ b/app/views/pets/edit.html.erb
@@ -1,17 +1,17 @@
 <div class="container">
   <div class="col-9 m-auto">
     <h3>ペット情報を編集する</h3>
-    <div class="form-pet-post rounded">
       <%= form_with model: @pet, url: pet_path, local: true, multipart: true do |f| %>
-        <div class="form-pet-post rounded mt-5 mb-2">
-          <%= fields_for @pet_images do |img| %>
-            <div class="image_input-label text-center">
-              <%= img.label :photos, '画像選択', class: 'image_input_btn' %>
-              <%= img.file_field :photos, multiple: true, include_hidden: false, class: 'image_form' %>
-              <span>４枚まで登録可能</span>
-            </div>
-          <% end %>
-        </div>
+        <div class="form-pet-post rounded">
+          <div class="form-pet-post rounded mt-5 mb-2">
+            <%= fields_for @pet_images do |img| %>
+              <div class="image_input-label text-center">
+                <%= img.label :photos, '画像選択', class: 'image_input_btn' %>
+                <%= img.file_field :photos, multiple: true, include_hidden: false, class: 'image_form' %>
+                <span>４枚まで登録可能</span>
+              </div>
+            <% end %>
+          </div>
         </div>
         <div class="form-pet-post rounded mt-5">
           <div class="form-label">
@@ -70,6 +70,6 @@
             <%= f.submit 'ペット情報変更', class: 'btn btn-lg comfirm-btn btn-block' %>
           </div>
       <% end %>
-      </div>
-      </div>
+    </div>
+  </div>
 </div>

--- a/spec/features/pets_edit_spec.rb
+++ b/spec/features/pets_edit_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature 'ペット詳細情報', type: :feature do
       end
 
       scenario 'ペット情報を正しく値を入力した場合、ペット詳細画面に遷移すること' do
-        expect(page).to have_current_path pet_path(Pet.last.id)
+                expect(page).to have_current_path pet_path(Pet.last.id)
       end
 
       scenario 'ペット情報を正しく値を入力した場合、flash メッセージが正しく表示されていること' do

--- a/spec/features/user_show_spec.rb
+++ b/spec/features/user_show_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature 'マイページ表示', type: :feature do
           end
 
           scenario '新着メッセージがあります。が表示されていること' do
-            expect(page).to have_content '新着メッセージがあります。'
+            expect(page).to have_content '新着メッセージがあります'
           end
         end
 


### PR DESCRIPTION
## 実装内容
ペット編集に遷移後に'ペット情報変更'ボタンが動作しない現象の改善
RSpecでフェイルが発生しているため、改善

## 完了条件
'ペット情報変更'ボタンが正常に動作すること
RSpecがパスすること