### PR TITLE
#100 TOP画面のセレクトボックスの新着順、登録順を再読み込みなしで変更

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,3 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
-import "@hotwired/turbo-rails"
-import "controllers"
+import "@hotwired/turbo-rails";
+import "controllers";

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,9 +1,10 @@
-import { Application } from "@hotwired/stimulus"
+import { Application } from "@hotwired/stimulus";
+import "./search_controller";
 
-const application = Application.start()
+const application = Application.start();
 
 // Configure Stimulus development experience
-application.debug = false
-window.Stimulus   = application
+application.debug = false;
+window.Stimulus = application;
 
-export { application }
+export { application };

--- a/app/javascript/controllers/search_controller.js
+++ b/app/javascript/controllers/search_controller.js
@@ -1,0 +1,13 @@
+// app/javascript/controllers/search_controller.js
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  connect() {
+    this.element.addEventListener("input", () => {
+      clearTimeout(this.timeout);
+      this.timeout = setTimeout(() => {
+        this.element.requestSubmit();
+      }, 500); // 500ミリ秒のデバウンス時間
+    });
+  }
+}

--- a/app/models/pet_area.rb
+++ b/app/models/pet_area.rb
@@ -1,4 +1,9 @@
 class PetArea < ApplicationRecord
   belongs_to :pet
   belongs_to :area
+
+  validates :pet_id, presence: true
+  validates :area_id, presence: true
+
+  validates :pet_id, uniqueness: { scope: :area_id }
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
   <!-- 投稿pet一覧 -->
-  <%= search_form_for @q, url: search_home_index_path do |f| %>
+  <%= search_form_for @q, url: search_home_index_path, html: { data: { turbo_frame: "pets" } } do |f| %>
     <div class="container-fluid ">
       <div class="row">
         <div class="col-xs-12 col-md-2">

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -59,7 +59,7 @@
               <%= render 'pets/pet_card', pet: pet %>
             <% end %>
           <% else %>
-            <h3 class="mt-3 text-center text-gray">ピックアップはありません。。</h3>
+            <h3 class="mt-3 text-center text-gray">ピックアップはありません。</h3>
           <% end %>
 
         </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
   <!-- 投稿pet一覧 -->
-  <%= search_form_for @q, url: search_home_index_path, html: { data: { turbo_frame: "pets" } } do |f| %>
+  <%= search_form_for @q, url: search_home_index_path, html: { data: { controller: "search", turbo_frame: "pets" } } do |f| %>
     <div class="container-fluid ">
       <div class="row">
         <div class="col-xs-12 col-md-2">
@@ -45,7 +45,8 @@
 
     </div>
     <br>
-    <%= f.submit '検索する', class: 'btn btn-lg comfirm-btn btn-block' %>
+    <%= f.submit '検索する', class: 'btn btn-lg comfirm-btn btn-block', data: { turbo: false } %>
+
 
     <div class="mt-5">
       <h2>Pickup</h2>
@@ -77,7 +78,7 @@
   <% end %>
   <hr>
 
-  <%= turbo_frame_tag 'pets' do %>
+  <%= turbo_frame_tag "pets" do %>
     <div class='mt-5'>
       <div id="all-pets-area">
         <div class="row">
@@ -93,5 +94,5 @@
     </div>
     <!-- 投稿pet一覧 end-->
     <%= paginate @pets, theme: 'bootstrap-5' %>
-  <% end %>
+ <% end %>
 </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,82 +1,83 @@
 <div class="container">
   <!-- 投稿pet一覧 -->
-  <div class="">
-    <%= search_form_for @q, url: search_home_index_path do |f| %>
-      <div class="container-fluid ">
+  <%= search_form_for @q, url: search_home_index_path do |f| %>
+    <div class="container-fluid ">
+      <div class="row">
+        <div class="col-xs-12 col-md-2">
+          <%= f.label :category %>
+          <%= f.select :category_eq,
+                       Pet.categories_i18n.invert.map { |key, value| [key, Pet.categories[value]] },
+                       { include_blank: '全て' },
+                       { class: 'form-select form-select-lg' } %>
+        </div>
+        <div class="col-xs-12 col-md-2">
+          <%= f.label :gender %>
+          <%= f.select :gender_eq,
+                       Pet.genders_i18n.invert.map { |key, value| [key, Pet.genders[value]] },
+                       { include_blank: '全て' },
+                       { class: 'form-select form-select-lg' } %>
+        </div>
+
+        <div class="col-xs-12 col-md-2">
+          <%= f.label :age %>
+          <%= f.number_field :age_lteq, { in: 1..30, class: 'form-control' } %>才まで
+        </div>
+
+        <div class="col-xs-12 col-md-2">
+          <%= f.label :classification %>
+          <%= f.select :classification_eq,
+                       Pet.classifications_i18n.invert.map { |key, value| [key, Pet.classifications[value]] },
+                       { include_blank: '全て' },
+                       { class: 'form-select form-select-lg' } %>
+        </div>
+
+      </div>
+
+      <div class="form-label">
+        <div class="field">
+          <%= f.label :pet_areas_area_id_in, "譲渡可能地域" %><br/>
+          <%= f.collection_check_boxes(:pet_areas_area_id_in, Area.all, :id, :place_name, include_hidden: false) do |area| %>
+            <%= area.label(class: "btn form-check-label") { area.check_box(class: "form-check-input") + area.text } %>
+          <% end %>
+        </div>
+      </div>
+
+
+    </div>
+    <br>
+    <%= f.submit '検索する', class: 'btn btn-lg comfirm-btn btn-block' %>
+
+    <div class="mt-5">
+      <h2>Pickup</h2>
+      <hr>
+
+      <div id="pickup-area">
         <div class="row">
-          <div class="col-xs-12 col-md-2">
-            <%= f.label :category %>
-            <%= f.select :category_eq,
-                         Pet.categories_i18n.invert.map { |key, value| [key, Pet.categories[value]] },
-                         { include_blank: '全て' },
-                         { class: 'form-select form-select-lg' } %>
-          </div>
-          <div class="col-xs-12 col-md-2">
-            <%= f.label :gender %>
-            <%= f.select :gender_eq,
-                         Pet.genders_i18n.invert.map { |key, value| [key, Pet.genders[value]] },
-                         { include_blank: '全て' },
-                         { class: 'form-select form-select-lg' } %>
-          </div>
-
-          <div class="col-xs-12 col-md-2">
-            <%= f.label :age %>
-            <%= f.number_field :age_lteq, { in: 1..30, class: 'form-control' } %>才まで
-          </div>
-
-          <div class="col-xs-12 col-md-2">
-            <%= f.label :classification %>
-            <%= f.select :classification_eq,
-                         Pet.classifications_i18n.invert.map { |key, value| [key, Pet.classifications[value]] },
-                         { include_blank: '全て' },
-                         { class: 'form-select form-select-lg' } %>
-          </div>
-
-        </div>
-
-        <div class="form-label">
-          <div class="field">
-            <%= f.label :pet_areas_area_id_in, "譲渡可能地域" %><br/>
-            <%= f.collection_check_boxes(:pet_areas_area_id_in, Area.all, :id, :place_name, include_hidden: false) do |area| %>
-              <%= area.label(class: "btn form-check-label") { area.check_box(class: "form-check-input") + area.text } %>
+          <% if @pickups.present? %>
+            <% @pickups.each do |pet| %>
+              <%= render 'pets/pet_card', pet: pet %>
             <% end %>
-          </div>
-        </div>
+          <% else %>
+            <h3 class="mt-3 text-center text-gray">ピックアップはありません。。</h3>
+          <% end %>
 
-
-      </div>
-      <br>
-      <%= f.submit '検索する', class: 'btn btn-lg comfirm-btn btn-block' %>
-
-      <div class="mt-5">
-        <h2>Pickup</h2>
-        <hr>
-
-        <div id="pickup-area">
-          <div class="row">
-            <% if @pickups.present? %>
-              <% @pickups.each do |pet| %>
-                <%= render 'pets/pet_card', pet: pet %>
-              <% end %>
-            <% else %>
-              <h3 class="mt-3 text-center text-gray">ピックアップはありません。。</h3>
-            <% end %>
-
-          </div>
         </div>
       </div>
-      <div class="row mt-md-4">
-        <div class="col-md-9">
-          <h2>掲載中の里親募集</h2>
-        </div>
-        <div class="col-md-3">
-          <div>
-            <%= f.select(:sorts, { '新着順': 'id desc', '登録順': 'id asc' }, { selected: params[:q][:sorts] }, { class: 'form-select form-select-lg' }) %>
-          </div>
+    </div>
+    <div class="row mt-md-4">
+      <div class="col-md-9">
+        <h2>掲載中の里親募集</h2>
+      </div>
+      <div class="col-md-3">
+        <div>
+          <%= f.select(:sorts, { '新着順': 'id desc', '登録順': 'id asc' }, { selected: params[:q][:sorts] }, { class: 'form-select form-select-lg' }) %>
         </div>
       </div>
-    <% end %>
-    <hr>
+    </div>
+  <% end %>
+  <hr>
+
+  <%= turbo_frame_tag 'pets' do %>
     <div class='mt-5'>
       <div id="all-pets-area">
         <div class="row">
@@ -90,7 +91,7 @@
         </div>
       </div>
     </div>
-  </div>
-  <!-- 投稿pet一覧 end-->
-  <%= paginate @pets, theme: 'bootstrap-5' %>
+    <!-- 投稿pet一覧 end-->
+    <%= paginate @pets, theme: 'bootstrap-5' %>
+  <% end %>
 </div>

--- a/app/views/pets/_pet_card.html.erb
+++ b/app/views/pets/_pet_card.html.erb
@@ -19,7 +19,7 @@
               <% end %>
               <p class="card-text"><%= pet.introduction %></p>
               <div class="button_to">
-                <%= link_to 'ペット詳細情報を確認', pet_path(pet.id), class: "btn btn-primary " %>
+                <%= link_to 'ペット詳細情報を確認', pet_path(pet.id), class: "btn btn-primary", data: { turbo: false } %>
               </div>
 
               <%= render partial: 'pets/favorite_button', locals: { pet: pet, current_user: current_user } %>

--- a/app/views/rooms/index.html.erb
+++ b/app/views/rooms/index.html.erb
@@ -49,10 +49,10 @@
           <% end %>
         <% end %>
         <% unless displayed_rooms %>
-          <h4 class="px-lg-4">表示するメッセージがありません。</h4>
+          <h4 class="px-lg-4 text-gray">表示するメッセージがありません。</h4>
         <% end %>
       <% else %>
-        <h4 class="px-lg-4">表示するルームがありません。</h4>
+        <h4 class="px-lg-4 text-gray">表示するルームがありません。</h4>
       <% end %>
 
       <%= paginate @rooms, theme: 'bootstrap-5' %>

--- a/db/migrate/20221108215600_create_pet_areas.rb
+++ b/db/migrate/20221108215600_create_pet_areas.rb
@@ -1,8 +1,8 @@
 class CreatePetAreas < ActiveRecord::Migration[7.0]
   def change
     create_table :pet_areas do |t|
-      t.references :pet, foreign_key: true
-      t.references :area, foreign_key: true
+      t.references :pet, null: false, foreign_key: true
+      t.references :area, null: false, foreign_key: true
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -52,8 +52,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_31_062139) do
   end
 
   create_table "pet_areas", force: :cascade do |t|
-    t.bigint "pet_id"
-    t.bigint "area_id"
+    t.bigint "pet_id", null: false
+    t.bigint "area_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["area_id"], name: "index_pet_areas_on_area_id"

--- a/spec/models/pet_area_spec.rb
+++ b/spec/models/pet_area_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe PetArea, type: :model do
+  describe 'バリデーション' do
+    let(:pet) { create(:pet) }
+    let(:area) { create(:area) }
+
+    it '有効な属性があれば有効であること' do
+      pet_area = PetArea.new(pet:, area:)
+
+      expect(pet_area).to be_valid
+    end
+
+    it 'petが存在しない場合は無効であること' do
+      pet_area = PetArea.new(area:)
+
+      expect(pet_area).not_to be_valid
+      pet_area.valid?
+      expect(pet_area.errors[:pet]).to include('を入力してください')
+    end
+
+    it 'areaが存在しない場合は無効であること' do
+      pet_area = PetArea.new(pet:)
+
+      expect(pet_area).not_to be_valid
+      pet_area.valid?
+      expect(pet_area.errors[:area]).to include('を入力してください')
+    end
+  end
+end


### PR DESCRIPTION
## 実施内容
- TOP画面のセレクトボックスの新着順、登録順を再読み込みなしで変更

## 完了条件
- 検索機能が正しく動作すること